### PR TITLE
Removing global dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ HTML5 Twitter Bootstrap 3 Boilerplate with Gulp and ES2015 modules
 
 ### How to use
 
-1. Run **npm install** to install dev dependencies
-2. Run **bower install** to install front dependencies
-3. Run **gulp serve** to work or **gulp** to build
+1. Run `npm install` to install dependencies
+2. Run `gulp serve` to work or `gulp` to build
+
+### Installing frontend dependencies
+Since we chose to use bower to manage our frontend dependencies, you can run bower through a npm script called `bower`. For example, if you wanna install jQuery, you can run `npm run bower -- install jquery --save`. DO NOT forget the `--` after the `npm run bower`, otherwise it'll just run `bower` without any parameters.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ HTML5 Twitter Bootstrap 3 Boilerplate with Gulp and ES2015 modules
 ### How to use
 
 1. Run `npm install` to install dependencies
-2. Run `gulp serve` to work or `gulp` to build
+2. Run `npm start` to work or `npm run build` to build
 
 ### Installing frontend dependencies
 Since we chose to use bower to manage our frontend dependencies, you can run bower through a npm script called `bower`. For example, if you wanna install jQuery, you can run `npm run bower -- install jquery --save`. DO NOT forget the `--` after the `npm run bower`, otherwise it'll just run `bower` without any parameters.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "web.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "bower": "bower",
     "postinstall": "bower install"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "HTML5 Twitter Bootstrap 3 Boilerplate with Gulp and ES2015 modules",
   "main": "web.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "bower install"
   },
   "repository": {
     "type": "git",
@@ -38,6 +39,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babelify": "^8.0.0",
+    "bower": "^1.8.2",
     "browser-sync": "^2.23.2",
     "browserify": "^14.5.0",
     "del": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "bower": "bower",
+    "start": "gulp serve",
+    "build": "gulp",
     "postinstall": "bower install"
   },
   "repository": {


### PR DESCRIPTION
Adds bower as a dev-dependency and uses the gulp binaries that are already present. Together with that, adds a couple of scripts:

- `npm start` replaces the old `gulp serve` to open the development server
- `npm run build` replaces the old `gulp` that builds the production-ready files on the `dist/` folder
- `postinstall` executes `bower install` after running `npm install` so the user doesn't have to do it manually (and probably forget it)
- `npm run bower`* proxies bower tasks to install frontend dependencies, for example. Usage: `npm run bower -- install jquery --save`

* I don't think the bower script is a very good idea, but it's a tradeoff to have a zero-dependency boilerplate.